### PR TITLE
Fix libbech32 submodule refs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libbech32"]
 	path = libbech32
-	url = git@github.com:dcdpr/libbech32.git
+	url = https://github.com/dcdpr/libbech32.git

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Now you can again try to build libtxref.
 If you got this code by cloning the github repo:
 
 ```
-git clone git@github.com:dcdpr/libtxref.git
+git clone https://github.com/dcdpr/libtxref.git
 ```
 
 then you will need to do a few extra steps to make sure you have everything:
@@ -198,7 +198,7 @@ you pass --recurse-submodules to the git clone command, it will
 automatically initialize and update each submodule in the repository:
 
 ```
-git clone --recurse-submodules git@github.com:dcdpr/libtxref.git
+git clone --recurse-submodules https://github.com/dcdpr/libtxref.git
 ```
 
 ## Regarding bech32 checksums


### PR DESCRIPTION
It seems that originally I had the libbech32 submodule added via the SSH-style 'git@..." reference. This means only someone with a github account and ssh key all set up would be able to fully clone the libtxref project. I have switched it to be an HTTPS-style reference, so now anyone should be able to clone it. I have also updated the specific commit reference so that it points to the very latest libbech32 commit.