### PR TITLE
minor tweak for handling CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,13 @@ set(LIBTXREF_BUILD_EXAMPLES ON CACHE BOOL "Build example executables")
 
 set(INSTALL_LIBTXREF ON CACHE BOOL "Enable installation")
 
+# Set default install prefix if we are top-level project, but only
+# if it hasn't been set on the command line
+if(NOT DEFINED CMAKE_INSTALL_PREFIX)
+  if(NOT WIN32 AND CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(CMAKE_INSTALL_PREFIX "/opt/contract.design/libtxref" CACHE PATH "" FORCE)
+  endif()
+endif()
 
 # Project
 
@@ -68,10 +75,6 @@ option(LIBBECH32_BUILD_RAPIDCHECK OFF)
 option(INSTALL_LIBBECH32 "Enable installation" ON)
 add_subdirectory(libbech32)
 
-# set default install prefix if we are top-level project
-if(NOT WIN32 AND CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  set(CMAKE_INSTALL_PREFIX "/opt/contract.design/libtxref")
-endif()
 
 add_subdirectory(libtxref)
 


### PR DESCRIPTION
set default install prefix if we are top-level project, but only if it hasn't been set on the command line